### PR TITLE
Add GitHub Actions workflows for manual and tag-based releases

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,58 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (leave empty to use module.json version)'
+        required: false
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        
+    - name: Extract version from module.json
+      id: version
+      run: |
+        if [ -n "${{ github.event.inputs.version }}" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+        else
+          VERSION=$(node -p "require('./module.json').version")
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Using version: $VERSION"
+        
+    - name: Create module.zip
+      run: |
+        # Create zip file with all necessary files
+        zip -r module.zip . -x "*.git*" "*.github*" "node_modules/*" "*.zip"
+        echo "Created module.zip"
+        
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ steps.version.outputs.version }}
+        name: Release v${{ steps.version.outputs.version }}
+        body: |
+          ## How unfortunate are you? Dice Counting v${{ steps.version.outputs.version }}
+          
+          ### Changes
+          - Manual release
+          
+          ### Installation
+          Download the `module.zip` file and install it in your Foundry VTT modules directory.
+        files: module.zip
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release Module
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        
+    - name: Extract version from module.json
+      id: version
+      run: |
+        VERSION=$(node -p "require('./module.json').version")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
+        
+    - name: Create module.zip
+      run: |
+        # Create zip file with all necessary files
+        zip -r module.zip . -x "*.git*" "*.github*" "node_modules/*" "*.zip"
+        echo "Created module.zip"
+        
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.ref }}
+        name: Release v${{ steps.version.outputs.version }}
+        body: |
+          ## How unfortunate are you? Dice Counting v${{ steps.version.outputs.version }}
+          
+          ### Changes
+          - Automated release
+          
+          ### Installation
+          Download the `module.zip` file and install it in your Foundry VTT modules directory.
+        files: module.zip
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduces two workflows: one for manual releases triggered via workflow dispatch with optional version input, and another for automated releases triggered by pushing tags. Both workflows package the module, create a zip file, and publish a GitHub release with installation instructions.